### PR TITLE
External format of integers (OTP-8540)

### DIFF
--- a/lib/bert/types.rb
+++ b/lib/bert/types.rb
@@ -15,7 +15,7 @@ module BERT
     FUN = 117
     NEW_FUN = 112
     MAGIC = 131
-    MAX_INT = (1 << 27) -1
-    MIN_INT = -(1 << 27)
+    MAX_INT = (1 << 31) -1
+    MIN_INT = -(1 << 31)
   end
 end


### PR DESCRIPTION
Hello!

Here I've contributed a minor change which enables one to make use of all 32 bits of integer while marshalling which described at http://erlang.org/download/otp_src_R14B.readme
