### PR TITLE
Supporting serialization of arbitrary objects

### DIFF
--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -20,6 +20,7 @@ module BERT
     end
 
     def write_any_raw obj
+      obj = obj.to_bert if obj.respond_to?(:to_bert)
       case obj
         when Symbol then write_symbol(obj)
         when Fixnum, Bignum then write_fixnum(obj)
@@ -27,8 +28,7 @@ module BERT
         when Tuple then write_tuple(obj)
         when Array then write_list(obj)
         when String then write_binary(obj)
-        else
-          fail(obj)
+        else fail(obj)
       end
     end
 


### PR DESCRIPTION
I've implemented a super-simple (just one line of code) yet significant improvement in my fork:

http://github.com/bendiken/bert/commit/bc48200fda886f560d8611559f0233a280bb8faa

This makes `BERT.encode` rather more useful by allowing it to serialize any Ruby object as long as that object responds to the `#to_bert` method, which should return the BERT representation of the object.

This is a feature we very much need for [RDF::BERT](http://github.com/bendiken/rdf-bert). With this patch, it now becomes possible to do things like the following:

```
require 'rdf'
require 'bert'

class RDF::Literal
  def to_bert
    BERT::Tuple[:literal, value.to_s, {:language => language.to_sym}]
  end
end

p BERT.encode(RDF::Literal("Hello!", :language => :en))
```

Much appreciated if this could be merged, it's a pretty trivial and non-invasive change but opens the door to new use cases such as the above.
