### PR TITLE
Encoding fixes with Ruby 1.9

### DIFF
--- a/lib/bert/decode.rb
+++ b/lib/bert/decode.rb
@@ -113,7 +113,7 @@ module BERT
       value = read_4
       negative = (value >> 31)[0] == 1
       value = (value - (1 << 32)) if negative
-      value = Fixnum.induced_from(value)
+      attempt_cast(Fixnum, value)
     end
 
     def read_small_bignum
@@ -126,7 +126,7 @@ module BERT
         value = (byte * (256 ** index))
         sign != 0 ? (result - value) : (result + value)
       end
-      Bignum.induced_from(added)
+      attempt_cast(Bignum, added)
     end
 
     def read_large_bignum
@@ -139,7 +139,7 @@ module BERT
         value = (byte * (256 ** index))
         sign != 0 ? (result - value) : (result + value)
       end
-      Bignum.induced_from(added)
+      attempt_cast(Bignum, added)
     end
 
     def read_float
@@ -243,6 +243,16 @@ module BERT
 
     def fail(str)
       raise str
+    end
+
+    private
+
+    def attempt_cast(klass, value)
+      if klass.respond_to?(:induced_from)
+        klass.induced_from(value)
+      else
+        value
+      end
     end
   end
 end

--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -11,7 +11,13 @@ module BERT
     def self.encode(data)
       io = StringIO.new
       self.new(io).write_any(data)
-      io.string
+
+      # set correct encoding type
+      if io.string.respond_to?(:force_encoding)
+        io.string.force_encoding("ASCII-8BIT")
+      else
+        io.string
+      end
     end
 
     def write_any obj


### PR DESCRIPTION
This branch fixes a couple of encoding issues when using Bert with Ruby 1.9.

When decoding Bert uses the #induced_from method which was deprecated in Ruby 1.8, but has now been removed. This checks it and works around it.

When encoding the encoded Bert string should be ASCII but defaults to whatever your interpreters default encoding is. This casts it to be ASCII-8BIT. This caused issues when using Bert with Ernie, as Ernie calls #length on the string, which is different from the actual string size (#bytesize). This was resulting in invalid terms being returned our Erlang nodes, which were blowing up when running binary_to_term/1 :)
