### PR TITLE
fixed encoding for utf8 string in ruby 1.9

### DIFF
--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -57,7 +57,7 @@ module BERT
       fail(sym) unless sym.is_a?(Symbol)
       data = sym.to_s
       write_1 ATOM
-      write_2 data.length
+      write_2 data.bytesize
       write_string data
     end
 
@@ -126,7 +126,7 @@ module BERT
 
     def write_binary(data)
       write_1 BIN
-      write_4 data.length
+      write_4 data.bytesize
       write_string data
     end
 

--- a/test/encoder_test.rb
+++ b/test/encoder_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'test_helper'
 
 class EncoderTest < Test::Unit::TestCase
@@ -77,6 +79,16 @@ class EncoderTest < Test::Unit::TestCase
       assert cruby.instance_of?(BERT::Tuple)
       assert cruby[0].instance_of?(Symbol)
       assert cruby[1].instance_of?(BERT::Tuple)
+    end
+    
+    should 'handle utf8 strings' do
+      bert = [131, 109, 0, 0, 0, 5, 195, 169, 116, 195, 169].pack('C*')
+      assert_equal bert, BERT::Encoder.encode("été")
+    end
+    
+    should 'handle utf8 symbols' do
+      bert = [131, 100, 0, 5, 195, 169, 116, 195, 169].pack('C*')
+      assert_equal bert, BERT::Encoder.encode(:'été')
     end
 
     should "handle bignums" do


### PR DESCRIPTION
utf8 strings are not encoded properly in 1.9, the size is wrong.

Glad to see this project is not completely dead, BERT is my favorite encoding library out there !
