### PR TITLE
Replace deprecated (since ruby2.4) Fixnum, Bignum by Integer

### DIFF
--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -23,7 +23,7 @@ module BERT
     def write_any_raw obj
       case obj
         when Symbol then write_symbol(obj)
-        when Fixnum, Bignum then write_fixnum(obj)
+        when Integer then write_fixnum(obj)
         when Float then write_float(obj)
         when Tuple then write_tuple(obj)
         when Array then write_list(obj)


### PR DESCRIPTION
This replaces the class Bignum and Fixnum by Integer, as they are deprecated since ruby2.4, and removed in ruby3.2.